### PR TITLE
nccl-ep: add the EP include root to the JIT compile include path

### DIFF
--- a/nccl_ep/device/jit/nvcc_compiler.cc
+++ b/nccl_ep/device/jit/nvcc_compiler.cc
@@ -54,6 +54,13 @@ std::vector<std::string> include_options(const JitCompileConfig& config) {
     // Include nccl_ep kernel headers and common.hpp
     add_include(config.source_dir);
     add_include(config.source_dir / "device");
+    // The EP install include root (parent of the staged nccl_ep/ dir). Needed so
+    // JIT-compiled kernels resolve the public "nccl_ep.h" (pulled in by ll_ep.cuh /
+    // ll_ep_adapter.cuh) and its internal "nccl_ep/ep_enums.h" self-reference. In a
+    // separate build tree (NCCL_EP_BUILDDIR != NCCL_HOME) build_include_dir points at
+    // the NCCL core include, which does not carry the EP public headers, so the EP
+    // include root must be added explicitly.
+    add_include(config.source_dir.parent_path());
 
     // Include all NCCL device headers
     if (!config.build_include_dir.empty()) {


### PR DESCRIPTION
## Problem

The JIT-compiled LL kernels pull in `device/ll_ep.cuh` and `device/ll_ep_adapter.cuh`,
which `#include "nccl_ep.h"` (the public API header). `nccl_ep.h` in turn does
`#include "nccl_ep/ep_enums.h"`. Resolving both at JIT-compile time requires the EP
install include root — `INCDIR`, the **parent** of the staged `nccl_ep/` dir — on the
JIT `-I` path.

`include_options()` (device/jit/nvcc_compiler.cc) added `source_dir`
(`INCDIR/nccl_ep`), `source_dir/device`, and `build_include_dir` — where
`build_include_dir` resolves to `NCCL_HOME/include`.

- **Co-located build** (`NCCL_EP_BUILDDIR == NCCL_HOME`, the Makefile default):
  `NCCL_HOME/include` == `INCDIR`, so `nccl_ep.h` and `nccl_ep/ep_enums.h` happen to
  resolve. Works.
- **Separate build tree** (`NCCL_EP_BUILDDIR != NCCL_HOME` — e.g. reusing a prebuilt
  NCCL core via `NCCL_HOME` while building EP into its own dir): `build_include_dir` is
  the **core** include, which carries neither `nccl_ep.h` nor `nccl_ep/ep_enums.h`. The
  runtime JIT compile fails:

  ```
  device/ll_ep.cuh:15:10: fatal error: nccl_ep.h: No such file or directory
     15 | #include "nccl_ep.h"
  [nccl_ep jit] fatal LL dispatch JIT launch failure ... compile failed
  ```

Note `nccl_ep.h` is **not** relocatable into `JIT_DIR` (`INCDIR/nccl_ep`): it
references its sibling headers as `nccl_ep/ep_enums.h`, which only resolves from
`INCDIR`. So the fix is to put `INCDIR` on the JIT path, not to copy the header.

## Fix

Add the EP include root — `config.source_dir.parent_path()` (i.e. `INCDIR`) — to the
JIT include options in `include_options()`. It resolves `nccl_ep.h` and its
`nccl_ep/ep_enums.h` reference regardless of whether the EP build tree is co-located
with or separate from `NCCL_HOME`. In the co-located case it equals
`build_include_dir` (a harmless duplicate `-I`). One line + a comment.

## Test plan

cw-dfw H100 (sm_90, CUDA 12.9, bundled NCCL 2.30.7). **Separate-tree** build
(`NCCL_EP_BUILDDIR=<repo>/ep_build_stagefix`, `NCCL_HOME=<prebuilt core>`) — the exact
config that failed before:

- Runtime JIT: no `nccl_ep.h: No such file` (and no `ep_enums.h` redefinition).
- `ep_bench --validate` (16 ranks / 2 nodes, hidden 7168, top-k 8, experts 256):
  LL rm@256 and LL em@256 → Dispatch=PASSED, Combine=PASSED.

Independent of the LL-JIT review-follow-up migration PR (this bug is on `main`).
