### PR TITLE
nccl_ep: generation-tag LL P2P signals so sibling handles cannot alias them

### DIFF
--- a/nccl_ep/device/jit/ll_combine_jit.cuh
+++ b/nccl_ep/device/jit/ll_combine_jit.cuh
@@ -66,7 +66,7 @@ inline std::string ll_combine_jit_source(
         << "      p.numExperts, p.currRank, p.numRanks,\n"
         << "      p.numWarpGroups, p.numWarpsPerGroup,\n"
         << "      p.phases, p.zeroCopy, p.numComms,\n"
-        << "      p.devComms, p.windows, p.signalsBase, p.timeoutCycles);\n"
+        << "      p.devComms, p.windows, p.signalsBase, p.signalGen, p.timeoutCycles);\n"
         << "}\n";
     return src.str();
 }

--- a/nccl_ep/device/jit/ll_dispatch_jit.cuh
+++ b/nccl_ep/device/jit/ll_dispatch_jit.cuh
@@ -68,7 +68,7 @@ inline std::string ll_dispatch_jit_source(
         << "      p.currRank, p.numRanks,\n"
         << "      p.numWarpGroups, p.numWarpsPerGroup,\n"
         << "      p.roundScale, p.recvTopkIdxKind, p.phases, p.numComms,\n"
-        << "      p.devComms, p.windows, p.signalsBase, p.timeoutCycles,\n"
+        << "      p.devComms, p.windows, p.signalsBase, p.signalGen, p.timeoutCycles,\n"
         << "      p.recvDataWindow, p.recvDataOffset, p.rcvScalesWin, p.rcvScalesOffs);\n"
         << "}\n";
     return src.str();

--- a/nccl_ep/device/ll_ep.cuh
+++ b/nccl_ep/device/ll_ep.cuh
@@ -435,6 +435,7 @@ __forceinline__ __device__ void sendExpertCount(
     int* recvCntBuf,
     int* rankMask,
     unsigned signalsBase,
+    unsigned signalGen,
     const ncclWindow_t* windows,
     ncclDevComm* devComms) {
     const auto dstP2pPtr = ncclGetP2pPtr(recvCntPtr, recvCntOffset, currRank, dstRank, windows, devComms);
@@ -459,7 +460,11 @@ __forceinline__ __device__ void sendExpertCount(
                 ncclGin_None{}, // no counter
                 ncclCoopThread());
         } else {
-            st_release_sys_global(reinterpret_cast<int*>(dstP2pPtr), -numTokensSent - 1);
+            // (gen << 16) | (count + 1): a sibling handle's or an older call's value
+            // carries a different generation and is ignored by the poll below.
+            st_release_sys_global(reinterpret_cast<int*>(dstP2pPtr),
+                                  (int)(((signalGen & 0x7fffu) << 16) |
+                                        ((unsigned)(numTokensSent + 1) & 0xffffu)));
         }
     }
 }
@@ -476,6 +481,7 @@ __forceinline__ __device__ int waitForRecvTokensRelaxed(
     int* rankMask,
     int* asyncErrorFlag,
     unsigned signalsBase,
+    unsigned signalGen,
     const ncclWindow_t* windows,
     ncclDevComm* devComms,
     int* recvStats,
@@ -506,10 +512,14 @@ __forceinline__ __device__ int waitForRecvTokensRelaxed(
         } else {
             // TODO: Double check that we can rely on this + __threadfence_system() in dispatch?
             // to ensure consistency on "another" SM that's going to access the data buffer protected by this atomic
-            while ((numRecvTokens = ld_acquire_sys_global((recvCntBuf + rankLaneIdx * numRanks + srcRank))) ==
-                       0 // data not arrived
+            int rawCnt;
+            while (((unsigned)(rawCnt = ld_acquire_sys_global(
+                        (recvCntBuf + rankLaneIdx * numRanks + srcRank))) >> 16) !=
+                       (signalGen & 0x7fffu) // this generation's count has not arrived
                    && (waitRecvCost = clock64() - startTime) <= timeoutCycles // not timeout
             );
+            if (((unsigned)rawCnt >> 16) == (signalGen & 0x7fffu))
+                numRecvTokens = -((rawCnt & 0xffff) - 1) - 1;
         }
     }
 
@@ -617,7 +627,8 @@ __device__ __forceinline__ void dispatch_kernel_impl( // INPUT
   // CONFIG
   int numTokens, int scalesPerToken, int maxTokensPerRank, int numTopk, int numExperts, int currRank, int numRanks,
   int numWarpGroups, int numWarpsPerGroup, bool roundScale, ncclEpExpertIdKind_t recvTopkIdxKind, int phases,
-  int numComms, ncclDevComm* devComms, const ncclWindow_t* windows, unsigned signalsBase, uint64_t timeoutCycles,
+  int numComms, ncclDevComm* devComms, const ncclWindow_t* windows, unsigned signalsBase,
+  unsigned signalGen, uint64_t timeoutCycles,
   // Zero-copy dispatch output (rank-major + nvlinkOnly): each available token
   // or SCALES_FORWARD scale window is written directly to its peer output.
   ncclWindow_t recvDataWindow, size_t recvDataOffset, ncclWindow_t rcvScalesWin, size_t rcvScalesOffs) {
@@ -892,6 +903,7 @@ __device__ __forceinline__ void dispatch_kernel_impl( // INPUT
             recvCntBuf,
             rankMask,
             signalsBase,
+            signalGen,
             windows,
             devComms);
 
@@ -949,6 +961,7 @@ LOW_LATENCY_DISPATCH_RECV:
                 rankMask,
                 asyncErrorFlag,
                 signalsBase,
+                signalGen,
                 windows,
                 devComms,
                 recvStats,
@@ -1350,6 +1363,7 @@ __forceinline__ __device__ void sendFinishFlag(
     int* recvFlagBuf,
     int* rankMask,
     unsigned signalsBase,
+    unsigned signalGen,
     const ncclWindow_t* windows,
     ncclDevComm* devComms) {
     auto dstP2pPtr = ncclGetP2pPtr(recvFlagPtr, recvFlagOffset, currRank, dstRank, windows, devComms);
@@ -1376,7 +1390,9 @@ __forceinline__ __device__ void sendFinishFlag(
                 ncclGin_None{}, // no counter
                 ncclCoopThread());
         } else {
-            st_release_sys_global(reinterpret_cast<int*>(dstP2pPtr), 1);
+            // (gen << 16) | 1 -- see the count send above.
+            st_release_sys_global(reinterpret_cast<int*>(dstP2pPtr),
+                                  (int)(((signalGen & 0x7fffu) << 16) | 1u));
         }
     }
 }
@@ -1392,6 +1408,7 @@ __forceinline__ __device__ void waitForRecvFlag(
     int* rankMask,
     int* asyncErrorFlag,
     unsigned signalsBase,
+    unsigned signalGen,
     const ncclWindow_t* windows,
     ncclDevComm* devComms,
     int64_t* waitStats,
@@ -1415,7 +1432,8 @@ __forceinline__ __device__ void waitForRecvFlag(
             );
             net.resetSignal(signalsBase + responsibleExpertIdx);
         } else {
-            while (ld_acquire_sys_global(recvFlagBuf + responsibleExpertIdx) == 0 // recv not ready
+            while (((unsigned)ld_acquire_sys_global(recvFlagBuf + responsibleExpertIdx) >> 16) !=
+                       (signalGen & 0x7fffu) // this generation's flag has not arrived
                    && (waitRecvCost = clock64() - startTime) <= timeoutCycles // not timeout
             );
         }
@@ -1603,7 +1621,7 @@ __device__ __forceinline__ void combine_kernel_impl( // INPUT
   // CONFIG
   int numCombinedTokens, int hidden, int numTopk, int maxTokensPerRank, int numExperts, int currRank, int numRanks,
   int numWarpGroups, int numWarpsPerGroup, int phases, bool zeroCopy, int numComms, ncclDevComm* devComms,
-  const ncclWindow_t* windows, unsigned signalsBase, uint64_t timeoutCycles) {
+  const ncclWindow_t* windows, unsigned signalsBase, unsigned signalGen, uint64_t timeoutCycles) {
     // Token dtype derivations
     constexpr int kElemBytes = (kTokenDtype == ncclFloat32) ? 4 : 2;
 
@@ -1845,6 +1863,7 @@ __device__ __forceinline__ void combine_kernel_impl( // INPUT
                 recvFlagBuf,
                 rankMask,
                 signalsBase,
+                signalGen,
                 windows,
                 devComms);
             atomic_add_release_global(atomicCleanFlag, -1);
@@ -1878,6 +1897,7 @@ LOW_LATENCY_COMBINE_RECV:
                 rankMask,
                 asyncErrorFlag,
                 signalsBase,
+                signalGen,
                 windows,
                 devComms,
                 waitStats,

--- a/nccl_ep/device/ll_ep_adapter.cu
+++ b/nccl_ep/device/ll_ep_adapter.cu
@@ -13,9 +13,37 @@
 #include "quantization_recipe.hpp"
 
 #include <algorithm>
+#include <atomic>
 
 namespace nccl_ep {
 namespace ll {
+
+// ----------------------------------------------------------------------------
+// LL P2P signal generations.
+//
+// The LL count/flag slots are addressed by offsets into the group's rdma_buffer,
+// but the parity that selects them (`handle->ll.buffer_idx`) is per-handle. Two
+// handles on one group therefore alias the same slots while advancing parity
+// independently, so a poll can observe a sibling handle's value -- and because the
+// values are workload-determined (finish flags are the constant 1) it is
+// indistinguishable from the one being waited for.
+//
+// Stamping every launch with a monotonically increasing generation, and accepting a
+// signal only when its generation matches, makes any foreign or leftover value inert.
+// Ranks run the same LL call sequence, so a per-process counter stays consistent
+// across them; a SEND-phase launch advances it and a RECV-only launch reuses it.
+// ----------------------------------------------------------------------------
+namespace {
+std::atomic<unsigned> gLlDispatchGen{0};
+std::atomic<unsigned> gLlCombineGen{0};
+// Never 0, so an all-zero (freshly cleaned) slot can never look like a valid signal.
+inline unsigned llNextGen(std::atomic<unsigned>& ctr, int phases) {
+    unsigned c = (phases & LOW_LATENCY_SEND_PHASE)
+                     ? ctr.fetch_add(1, std::memory_order_relaxed) + 1
+                     : ctr.load(std::memory_order_relaxed);
+    return (c - 1u) % 0x7fffu + 1u;
+}
+}  // namespace
 
 // Forward-declare the host-side `ceil_div` helper used here. `common.hpp`
 // provides templated ceil_div in namespace nccl_ep; we reuse it via ADL.
@@ -92,6 +120,7 @@ ncclResult_t call_dispatch(
     args.devComms = params.devComms;
     args.windows = params.windows;
     args.signalsBase = params.signalsBase;
+    args.signalGen = llNextGen(gLlDispatchGen, params.phases);
     args.timeoutCycles = params.timeoutCycles;
     args.recvDataWindow = params.recvDataWindow;
     args.recvDataOffset = params.recvDataOffset;
@@ -196,6 +225,7 @@ void call_combine(const CombineParams& params, cudaStream_t stream) {
     args.devComms = params.devComms;
     args.windows = params.windows;
     args.signalsBase = params.signalsBase;
+    args.signalGen = llNextGen(gLlCombineGen, params.phases);
     args.timeoutCycles = params.timeoutCycles;
 
     jit::launch_ll_combine(

--- a/nccl_ep/device/ll_ep_adapter.cuh
+++ b/nccl_ep/device/ll_ep_adapter.cuh
@@ -80,6 +80,8 @@ struct dispatch_kernel_args_t {
     ncclDevComm* devComms;
     const ncclWindow_t* windows;
     unsigned signalsBase;
+    // Per-launch generation stamped into every P2P count/flag signal value.
+    unsigned signalGen;
     uint64_t timeoutCycles;
     // Non-null windows enable peer payload writes.
     ncclWindow_t recvDataWindow;
@@ -126,6 +128,8 @@ struct combine_kernel_args_t {
     ncclDevComm* devComms;
     const ncclWindow_t* windows;
     unsigned signalsBase;
+    // Per-launch generation stamped into every P2P count/flag signal value.
+    unsigned signalGen;
     uint64_t timeoutCycles;
 };
 


### PR DESCRIPTION
Migrated from NVIDIA/nccl#2306 at @kwen2501's suggestion, now that NCCL-EP lives here. Fixes the LOW_LATENCY receive-timeout failure reported in NVIDIA/nccl#2303. Rebased onto this repo's layout (`low_latency.cu` → `ll_ep.cuh` + `ll_ep_adapter.cu`) and reshaped along the way — see "What changed versus the old PR".

## Root cause

The LL count/flag slots are addressed by offsets computed in `handle->ll.layout`, which point into **`group->rdma_buffer`** — per-group memory. The parity that selects between the two slots, `handle->ll.buffer_idx`, is **per-handle** state, flipped on each dispatch and combine (and it also picks `signal_base`).

So two handles created on one group with the same config compute *identical* offsets and alias the same parity-0/parity-1 count and flag slots, while each advances its own parity independently. The double-buffer invariant breaks across handles: one handle's "next buffer, safe to clean" is another handle's "current buffer, in flight". Cleans wipe live signals, and polls accept a sibling handle's leftover value — which is indistinguishable from the awaited one, because the values are workload-determined and finish flags are the constant `1`. Counts and flags share a single offset (`dispatch_rdma_recv_count_buffer_offset == combine_rdma_recv_flag_buffer_offset`), so both are affected.

The visible symptom is the systematic `NCCL EP timeout for dispatch/combine receive` warnings followed by `trap()` → `cudaErrorLaunchFailure` (719).

### Evidence

Stock `nccl4py[cu13]==0.3.1`, GB200, 4 ranks on one tray, identical workload; the only variable is how many LL handles the caller creates on the group:

| LL handles on the group | result |
|---|---|
| 1 | `rc=0`, zero receive timeouts, combine correctness passing |
| 2 | 64 dispatch + 6 combine receive timeouts → 719 |

`ep_bench` creates exactly one handle and so never hits this: it stayed green through eight configurations up to 20 000 iterations, including with its per-iteration `MPI_Barrier` removed, with a 500 ms stall injected on one rank, and with dispatch-only and combine-only timed loops. Rank stagger and loop shape are ruled out. Our own benchmark creates one handle per token count and interleaves them, so it fails almost immediately — and it fails the same way on x86 (H100, B200, B300), so this is not GB200/GB300- or MNNVL-specific.

## The fix

Stamp every LL launch with a monotonically increasing generation, carry it into the signal value, and accept a signal only when its generation matches:

```
count: (gen << 16) | (numTokensSent + 1)     accept iff value >> 16 == gen
flag:  (gen << 16) | 1                        accept iff value >> 16 == gen
```

A sibling handle's or an older call's value then carries a different generation and is inert. The generation is never 0, so a freshly cleaned (all-zero) slot can never be mistaken for a signal. Ranks execute the same LL call sequence, so a per-process counter stays consistent across them; a SEND-phase launch advances it, a RECV-only launch reuses it. The GIN path is untouched — its accumulating signals have different semantics.

## What changed versus the old PR

- **Rebased** onto `nccl_ep/device/ll_ep.cuh` and `ll_ep_adapter.cu`.
- **The generation is now a kernel argument** (`signalGen`, threaded exactly like the existing `signalsBase`) instead of a `__device__` symbol set with `cudaMemcpyToSymbol`. That was necessary here — the LL kernels are JIT-compiled, so a symbol in the AOT module would not be the one the kernel reads — and it is also the cleaner shape reviewers asked about on the old PR.
- **The root-cause description is corrected.** The old PR attributed the failure to a rank lapping a parity cycle, and claimed LL worked on x86. Both were wrong; details in NVIDIA/nccl#2303.

## Validation

- Runtime behaviour was validated on the pre-move code (`contrib/nccl_ep` at the commit the shipped wheel is built from), where the identical change turns a 100 %-reproducible wedge into full clean runs: decode ladders T=1…256, 2048 samples per point, dispatch and combine correctness passing, at world=4 (single tray, three runs) and world=8 (two trays).
- On this tree the ported change builds cleanly AOT (library and `ep_bench`).
- I could **not** exercise the JIT path end to end here: `main`'s LL kernels reference GIN device APIs (`ncclGin`, `ncclGin_SignalAdd`, `ncclGinSignal_t`) that are not in NCCL 2.30.7, the newest published `nvidia-nccl-cu13` wheel, so the runtime JIT compile fails. Unmodified `main` fails identically at the same sites in the same container, so this is an environment/version gap rather than something the patch introduces — but it does mean the JIT argument-list change here is compile-checked only through the AOT build, and a run on a tree with a matching NCCL would be worth doing before merge. Happy to re-run it if you can point me at the right NCCL revision.

## Open question

This makes stale and foreign values inert, which fixes the failure — but it is arguably a mitigation. The structural fix is to stop two handles sharing parity state and slots: per-handle signal regions, or one group-level parity counter that every handle advances. Happy to reshape it that way instead.

And if interleaving multiple LL handles on a single group is simply not intended to be supported, then the better outcome is a loud host-side error on the second `ncclEpInitHandle` for a group — today that usage costs a ~97 s timeout and a `trap()`, which is very hard to attribute.
